### PR TITLE
Add NPM install cache step to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,6 +320,9 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: NPM install cache
+        uses: c-hive/gha-npm-cache@v1
+
       - name: Publish package to npm (if present and not private)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces an improvement to the npm installation process in the GitHub Actions workflow by adding a caching step. This change helps speed up the build process by reusing previously installed npm dependencies.

Build process optimization:

* Added an `NPM install cache` step to `.github/workflows/build.yml` using the `c-hive/gha-npm-cache@v1` GitHub Action to cache npm dependencies and reduce install times.