### PR TITLE
fixing publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,8 +320,28 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: NPM install cache
-        uses: c-hive/gha-npm-cache@v1
+      - name: Install npm dependencies
+        run: |
+          set -euo pipefail
+          # Use npm ci when a lockfile is present for reproducible installs,
+          # otherwise fall back to npm install. Disable audit and funding
+          # messages to keep logs concise.
+          if [ -f package-lock.json ]; then
+            npm ci --prefer-offline --no-audit --no-fund
+          else
+            npm install --no-audit --no-fund
+          fi
+
+      - name: Cache node modules and npm cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          # Use lockfile and package.json hashes as part of the key for stability
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Publish package to npm (if present and not private)
         env:


### PR DESCRIPTION
This pull request updates the npm dependency installation and caching steps in the GitHub Actions workflow to improve reliability and reproducibility. The main changes are the replacement of the previous npm cache action with a more robust approach using the official `actions/cache` and a conditional install process.

**Improvements to npm install and caching:**

* Replaced the `c-hive/gha-npm-cache` action with a manual install step that uses `npm ci` when a lockfile is present, and falls back to `npm install` otherwise, both with audit and funding messages disabled for cleaner logs. (`.github/workflows/build.yml`)
* Added a new caching step using `actions/cache@v4` to cache both `~/.npm` and `node_modules`, with cache keys based on lockfile and `package.json` hashes for more stable and reliable caching. (`.github/workflows/build.yml`)