### PR TITLE
Fix/vite plugin process spawning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rds-analyzer",
-  "version": "0.5.5-alpha",
+  "version": "0.5.6-alpha",
   "description": "A memory-efficient dependency analyzer for JavaScript, TypeScript, and Vue projects",
   "main": "index.js",
   "bin": {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -17,6 +17,7 @@ module.exports = function rdsWatchPlugin(options = {}) {
   let exe = options.execPath || chooseExecutable();
   let args = ensureArray(options.args || ["--watch"]);
   const cwd = options.cwd || process.cwd();
+  const pidFile = path.join(cwd, ".rds-plugin.pid");
   const useShell =
     typeof options.useShell === "boolean"
       ? options.useShell
@@ -57,45 +58,50 @@ module.exports = function rdsWatchPlugin(options = {}) {
     return null;
   }
 
+  function matchShimPatterns(text, found) {
+    const patterns = [
+      /exec\s+["']?\$basedir[\\/]+([^"'\s]*rds(?:\.exe)?)["']?/i,
+      /require\(['"].*bin[\\/]([^"']*rds(?:\.exe)?)["']\)/i,
+      /path\.join\(.*__dirname.*[,\s]*['"]?\.\.[\\/]bin[\\/]([^'")]+)['"]?\)/i,
+    ];
+    for (const pat of patterns) {
+      const m = text.match(pat);
+      if (m && m[1]) {
+        const rel = m[1].replace(/\//g, path.sep);
+        const candidate = path.resolve(path.dirname(found), rel);
+        if (fs.existsSync(candidate)) return candidate;
+      }
+    }
+    return null;
+  }
+
+  function findNearbyBinCandidate(found) {
+    const tryDirs = [
+      path.dirname(found),
+      path.resolve(path.dirname(found), ".."),
+      path.resolve(path.dirname(found), "..", ".."),
+    ];
+    const names = ["rds.exe", "rds"];
+    for (const d of tryDirs) {
+      for (const n of names) {
+        const p = path.join(d, "bin", n);
+        if (fs.existsSync(p)) return p;
+      }
+    }
+    return null;
+  }
+
   function followShimIfNeeded(found) {
     try {
       if (!found) return null;
       if (!fs.existsSync(found)) return found;
-      // If the path is a symlink, prefer the real path
-      try {
-        const real = fs.realpathSync(found);
-        if (real && real !== found && fs.existsSync(real)) return real;
-      } catch (e) {
-        // ignore realpath failures
-      }
+      const real = fs.realpathSync(found);
+      if (real && real !== found && fs.existsSync(real)) return real;
       const text = fs.readFileSync(found, "utf8");
-      // try to detect common shim patterns that point to a bundled binary
-      const patterns = [
-        /exec\s+["']?\$basedir[\\\/]+([^"'\s]*rds(?:\.exe)?)["']?/i,
-        /require\(['"].*bin[\\\/]([^"']*rds(?:\.exe)?)["']\)/i,
-        /path\.join\(.*__dirname.*[,\s]*['"]?\.\.[\\\/]bin[\\\/]([^'"\)]+)['"]?\)/i,
-      ];
-      for (const pat of patterns) {
-        const m = text.match(pat);
-        if (m && m[1]) {
-          const rel = m[1].replace(/\//g, path.sep);
-          const candidate = path.resolve(path.dirname(found), rel);
-          if (fs.existsSync(candidate)) return candidate;
-        }
-      }
-      // fallback: look for common nearby bin/ candidates
-      const tryDirs = [
-        path.dirname(found),
-        path.resolve(path.dirname(found), ".."),
-        path.resolve(path.dirname(found), "..", ".."),
-      ];
-      const names = ["rds.exe", "rds"];
-      for (const d of tryDirs) {
-        for (const n of names) {
-          const p = path.join(d, "bin", n);
-          if (fs.existsSync(p)) return p;
-        }
-      }
+      const shimCandidate = matchShimPatterns(text, found);
+      if (shimCandidate) return shimCandidate;
+      const binCandidate = findNearbyBinCandidate(found);
+      if (binCandidate) return binCandidate;
     } catch {}
     return found;
   }
@@ -103,11 +109,17 @@ module.exports = function rdsWatchPlugin(options = {}) {
   function attachHandlers(c, attemptedExe, tried) {
     c.on("exit", (code) => {
       child = null;
+      try {
+        if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
+      } catch {}
       if (code && code !== 0)
         console.warn("[vite-plugin-rds-watch] rds exited with code", code);
     });
     c.on("close", () => {
       child = null;
+      try {
+        if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
+      } catch {}
     });
     c.on("error", (err) => {
       if (
@@ -117,12 +129,7 @@ module.exports = function rdsWatchPlugin(options = {}) {
         !tried.npx
       ) {
         tried.npx = true;
-        child = spawn("npx", ["rds", ...args], {
-          cwd,
-          stdio: "inherit",
-          shell: useShell,
-        });
-        attachHandlers(child, "npx", tried);
+  setChild(spawn("npx", ["rds", ...args], { cwd, stdio: "inherit", shell: useShell }), "npx", tried);
         return;
       }
       if (
@@ -132,12 +139,7 @@ module.exports = function rdsWatchPlugin(options = {}) {
         !tried.npm
       ) {
         tried.npm = true;
-        child = spawn("npm", ["exec", "--", "rds", ...args], {
-          cwd,
-          stdio: "inherit",
-          shell: useShell,
-        });
-        attachHandlers(child, "npm", tried);
+  setChild(spawn("npm", ["exec", "--", "rds", ...args], { cwd, stdio: "inherit", shell: useShell }), "npm", tried);
         return;
       }
       console.error(
@@ -147,17 +149,13 @@ module.exports = function rdsWatchPlugin(options = {}) {
     });
   }
 
-  async function start() {
-    if (serverClosed) return;
-    if (child) return;
+  function setChild(c, attemptedExe, tried) {
+    child = c;
+    try { if (child && child.pid) fs.writeFileSync(pidFile, String(child.pid), { encoding: 'utf8' }); } catch {}
+    attachHandlers(child, attemptedExe, tried);
+  }
 
-    try {
-      await stopChild();
-    } catch {}
-
-    if (serverClosed) return;
-    if (child) return;
-
+  function prepareSpawnArgs() {
     const spawnArgs = args.slice();
     const hasNonFlag = spawnArgs.some(
       (a) => typeof a === "string" && !a.startsWith("-")
@@ -174,17 +172,95 @@ module.exports = function rdsWatchPlugin(options = {}) {
         "--exclude",
         "node_modules|.git|.vite|dist|build|.cache"
       );
-    const spawnArgsForShell = spawnArgs.map(quoteIfNeeded);
-    // If no explicit execPath is provided, just run `npx rds` so the plugin
-    // uses the project-installed CLI (or the global one) consistently.
     if (!options.execPath) {
       exe = "npx";
       spawnArgs.unshift("rds");
     }
+    return spawnArgs;
+  }
+
+  async function start() {
+    if (serverClosed) return;
+    if (child) return;
+
+    try {
+      await stopChild();
+    } catch {}
+
+    if (serverClosed) return;
+    if (child) return;
+
+    // Ensure any orphaned pid recorded by a previous plugin instance is killed
+    // before we spawn a new process. Wait a short while (up to 5s) for it to
+    // disappear to avoid races where a lingering process and a new one both run.
+    await killPidFromFile().catch(() => {});
+    function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+    function isPidAlive(pid) {
+      try {
+        if (!pid) return false;
+        if (process.platform === 'win32') {
+          const r = spawnSync('tasklist', ['/FI', `PID eq ${pid}`], { encoding: 'utf8' });
+          return !!(r && r.stdout && r.stdout.indexOf(String(pid)) !== -1);
+        }
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    try {
+      if (fs.existsSync(pidFile)) {
+        const txt = fs.readFileSync(pidFile, 'utf8').trim();
+        const pid = Number(txt) || null;
+        if (pid) {
+          let waited = 0;
+          const maxWait = 5000;
+          while (isPidAlive(pid) && waited < maxWait) {
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(200);
+            waited += 200;
+          }
+          if (isPidAlive(pid)) {
+            // last attempt
+            await killPidFromFile().catch(() => {});
+            // If still alive, try killing by image name as a last resort
+            if (isPidAlive(pid)) {
+              await killByImageName().catch(() => {});
+            }
+            // give it a short moment
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(200);
+          }
+        }
+      }
+    } catch {}
+
+    // As an extra safeguard: kill by image name and wait for any rds
+    // processes to disappear before spawning a new one.
+    await killByImageName().catch(() => {});
+    function anyRdsRunning() {
+      try {
+        if (process.platform === 'win32') {
+          const r = spawnSync('tasklist', ['/FI', 'IMAGENAME eq rds.exe'], { encoding: 'utf8' });
+          return !!(r && r.stdout && r.stdout.indexOf('rds.exe') !== -1);
+        }
+        const r = spawnSync('pgrep', ['-f', 'rds'], { encoding: 'utf8' });
+        return !!(r && r.status === 0 && r.stdout && r.stdout.trim());
+      } catch {
+        return false;
+      }
+    }
+    const waitStart = Date.now();
+    while (anyRdsRunning() && Date.now() - waitStart < 3000) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const spawnArgs = prepareSpawnArgs();
+    const spawnArgsForShell = spawnArgs.map(quoteIfNeeded);
 
     let resolved = resolveCommand(exe);
     const spawnOptions = { cwd, stdio: "inherit", shell: useShell };
-    // On Windows prefer to spawn the real rds.exe directly (no shell) when available.
     if (process.platform === "win32" && useShell) {
       const found = findExecutableOnPath(exe);
       if (found) {
@@ -194,8 +270,7 @@ module.exports = function rdsWatchPlugin(options = {}) {
       }
     }
     const argsToPass = spawnOptions.shell ? spawnArgsForShell : spawnArgs;
-    child = spawn(resolved, argsToPass, spawnOptions);
-    attachHandlers(child, "rds", { npx: false, npm: false });
+  setChild(spawn(resolved, argsToPass, spawnOptions), "rds", { npx: false, npm: false });
   }
 
   function stopChild() {
@@ -245,10 +320,71 @@ module.exports = function rdsWatchPlugin(options = {}) {
             } catch {}
           }
           child = null;
+          try {
+            if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
+          } catch {}
           return resolve();
         }
       }, 200);
     });
+  }
+
+  // Try to kill a PID recorded in the pidFile. This helps when the plugin is
+  // re-initialized and the previous instance left an orphaned rds process.
+  async function killPidFromFile() {
+    try {
+      if (!fs.existsSync(pidFile)) return;
+      const txt = fs.readFileSync(pidFile, "utf8").trim();
+      const pid = Number(txt) || null;
+      if (!pid) {
+        try { fs.unlinkSync(pidFile); } catch {}
+        return;
+      }
+
+      function isPidAliveLocal(p) {
+        try {
+          if (!p) return false;
+          if (process.platform === 'win32') {
+            const r = spawnSync('tasklist', ['/FI', `PID eq ${p}`], { encoding: 'utf8' });
+            return !!(r && r.stdout && r.stdout.indexOf(String(p)) !== -1);
+          }
+          process.kill(p, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+
+      // Try to kill the pid synchronously on Windows, otherwise send SIGKILL.
+      if (process.platform === 'win32') {
+        try { spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', shell: true }); } catch {}
+      } else {
+        try { process.kill(pid, 'SIGKILL'); } catch {}
+      }
+
+      // Wait up to 5 seconds for the pid to disappear.
+      const start = Date.now();
+      while (isPidAliveLocal(pid) && Date.now() - start < 5000) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      try { if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile); } catch {}
+    } catch (err) {
+      try { console.debug && console.debug('[vite-plugin-rds-watch] killPidFromFile failed', err && err.message); } catch {}
+    }
+  }
+
+  async function killByImageName() {
+    try {
+      if (process.platform === 'win32') {
+        try { spawnSync('taskkill', ['/F', '/IM', 'rds.exe', '/T'], { stdio: 'ignore', shell: true }); } catch {}
+      } else {
+        try { spawnSync('pkill', ['-f', 'rds'], { stdio: 'ignore' }); } catch {}
+      }
+    } catch (err) {
+      try { console.debug && console.debug('[vite-plugin-rds-watch] killByImageName failed', err && err.message); } catch {}
+    }
   }
 
   function stop() {
@@ -268,18 +404,31 @@ module.exports = function rdsWatchPlugin(options = {}) {
 
   return {
     name: "vite-plugin-rds-watch",
-    configureServer(server) {
+    async configureServer(server) {
+      // Ensure any previously-running rds child is stopped before starting a new one.
+      // Use stopChild() here so we don't set the plugin into a permanently-closed state.
+      await stopChild().catch((err) => {
+        // best-effort: if stopChild fails, surface debug info but continue startup
+        try {
+          console.debug &&
+            console.debug("[vite-plugin-rds-watch] stopChild() failed", err);
+        } catch {}
+      });
+      await killPidFromFile().catch(() => {});
       start();
       if (stopOnServerClose)
         server.httpServer && server.httpServer.on("close", () => stop());
     },
-    handleHotUpdate(ctx) {
+    async handleHotUpdate(ctx) {
       const file = ctx.file || "";
       if (
         restartOnHotUpdate &&
         (file.endsWith("rds.config.toml") || file.includes("rds"))
       ) {
-        stop();
+        // For restarts we only need to stop the running child process, not mark
+        // the plugin as permanently closed.
+        await stopChild().catch(() => {});
+        await killPidFromFile().catch(() => {});
         start();
       }
       return [];


### PR DESCRIPTION
This pull request introduces significant improvements to the `vite-plugin-rds-watch` plugin's process management, making it more robust in handling orphaned or lingering `rds` processes, especially across plugin restarts and server reloads. The changes ensure that only one `rds` process runs at a time, reducing the risk of resource leaks or conflicts. Additionally, the code has been refactored for better modularity and maintainability.

**Process management enhancements:**

* Introduced a `.rds-plugin.pid` file to track the spawned `rds` process, and implemented logic to clean up this file and kill orphaned processes before starting new ones. This includes waiting for processes to exit and using platform-specific commands to ensure termination. [[1]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaR20) [[2]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaL150-R158) [[3]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaL177-L187) [[4]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaR323-R389)
* Added `killPidFromFile` and `killByImageName` helper functions to reliably terminate orphaned `rds` processes using PID files and process image names, with retries and platform-specific handling.
* Updated the plugin's lifecycle hooks (`configureServer`, `handleHotUpdate`) to asynchronously stop and clean up existing processes before starting new ones, ensuring no overlap or resource leaks during restarts or hot updates.

**Code structure and maintainability:**

* Refactored process spawning logic into helper functions (`setChild`, `prepareSpawnArgs`) for clarity and reuse, and improved the handling of process lifecycle events to ensure cleanup. [[1]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaL150-R158) [[2]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaL197-R273)
* Improved the shim detection logic by splitting out `matchShimPatterns` and `findNearbyBinCandidate` for better readability and maintainability. [[1]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaL60-R65) [[2]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaL86-R78) [[3]](diffhunk://#diff-286c0937f84c17fa56ecf84505f3a60451f817bd241390fd8b6b1898b14fd5aaR91-R122)

**Miscellaneous:**

* Bumped the package version from `0.5.5-alpha` to `0.5.6-alpha`.